### PR TITLE
ability to deploy db-conn settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ repository =>
     some other resource server.json
   database-connections
     my-connection-name
+      settings.json
       get_user.js
       login.js
   rules-configs

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "auth0-extension-tools": "1.3.2",
     "auth0-extension-ui": "^1.0.1",
     "auth0-oauth2-express": "^1.1.8",
-    "auth0-source-control-extension-tools": "3.0.10",
+    "auth0-source-control-extension-tools": "^3.0.10",
     "axios": "^0.15.0",
     "babel": "^6.5.2",
     "babel-core": "^6.9.1",


### PR DESCRIPTION
## ✏️ Changes
Added possibility to read `settings.json` of database connection. It should be placed at `/database-connections/[connection-name]/settings.json`, it can contain any connection settings, including `options`. Options will be merged with `customScripts`, if db-scripts are provided.
  
## 🔗 References
Slack: https://auth0.slack.com/archives/C9170558S/p1544222234120100
  
## 🎯 Testing
✅ This change has been tested locally
🚫 This change has unit test coverage
🚫 This change has integration test coverage
🚫 This change has been tested for performance
  
## 🚀 Deployment
✅ This can be deployed any time
  